### PR TITLE
Add ci-cd helper images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,10 +7,17 @@ steps:
     commands:
       - npm i -g markdown-link-check
       - find . -name \*.md | xargs -n1 markdown-link-check
+
   - name: lint-dockerfiles
     image: hadolint/hadolint:latest-debian
     commands:
-      - hadolint --failure-threshold warning **/*/Dockerfile
+      - find . -name \Dockerfile | xargs -n1 hadolint --failure-threshold warning
+
+  - name: success
+    image: alpine
+    depends_on: ["check-markdown-links", "lint-dockerfiles"]
+    commands:
+      - echo "success"
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,17 @@
+kind: pipeline
+name: default
+
+steps:
+    - name: check-markdown-links
+      image: node:lts
+      commands:
+        - npm i -g markdown-link-check
+        - find . -name \*.md | xargs -n1 markdown-link-check
+    - name: lint-dockerfiles
+      image: hadolint/hadolint
+      commands:
+        - hadolint **/*/Dockerfile
+
+trigger:
+    event:
+        - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,16 +2,16 @@ kind: pipeline
 name: default
 
 steps:
-    - name: check-markdown-links
-      image: node:lts
-      commands:
-        - npm i -g markdown-link-check
-        - find . -name \*.md | xargs -n1 markdown-link-check
-    - name: lint-dockerfiles
-      image: hadolint/hadolint
-      commands:
-        - hadolint **/*/Dockerfile
+  - name: check-markdown-links
+    image: node:lts
+    commands:
+      - npm i -g markdown-link-check
+      - find . -name \*.md | xargs -n1 markdown-link-check
+  - name: lint-dockerfiles
+    image: hadolint/hadolint:latest-debian
+    commands:
+      - hadolint --failure-threshold warning **/*/Dockerfile
 
 trigger:
-    event:
-        - pull_request
+  event:
+    - pull_request

--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 Repository for a collection of `Dockerfile`s that have helped us during development and during projects. Useful for local development, deployments and CI/CD pipelines.
 
 Currently, we offer:
-- `python-poetry` images and files, where `poetry` is the amazing [python package manager](https://python-poetry.org/). So far other images we found were outdated and unmaintained. We wanted to change that, as we believe in `poetry` as the future of python package management,
-- `aws-cli` + `chamber`  + `helm` images and files in order to support our continuous delivery, where:
+- `python/3.{8, 9}/poetry`: Where `poetry` is the amazing [python package manager](https://python-poetry.org/). So far other images we found were outdated and unmaintained. We wanted to change that, as we believe in `poetry` as the future of python package management
+    - image name: `sidestream/python-poetry`
+- `ci-cd/aws-cli-chamber-helm`: `aws-cli` + `chamber`  + `helm` images and files in order to support our continuous delivery, where:
     - `aws-cli` is used to connect to AWS infrastructure
     - `chamber` is used to securely inject secrets into the deployment,
     - `helm` is used to deploy the application
+    - image name: `sidestream/aws-cli-chamber-helm`
+- `ci-cd/docker-in-docker-chamber`: Docker-in-docker (dind) and `chamber` for docker build time configuration injection in CI/CD pipeline
+    - image name: `sidestream/docker-in-docker-chamber`
 
 You can find and pull [the images on docker hub](https://hub.docker.com/r/sidestream).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Repository for a collection of `Dockerfile`s that have helped us during development and during projects. Useful for local development, deployments and CI/CD pipelines.
 
-Currently, we only offer public `python-poetry` images and files, where `poetry` is the amazing [python package manager](https://python-poetry.org/). So far other images we found were outdated and unmaintained. We wanted to change that, as we believe in `poetry` as the future of python package management.
+Currently, we offer:
+- `python-poetry` images and files, where `poetry` is the amazing [python package manager](https://python-poetry.org/). So far other images we found were outdated and unmaintained. We wanted to change that, as we believe in `poetry` as the future of python package management,
+- `aws-cli` + `chamber`  + `helm` images and files in order to support our continuous delivery, where:
+    - `aws-cli` is used to connect to AWS infrastructure
+    - `chamber` is used to securely inject secrets into the deployment,
+    - `helm` is used to deploy the application
 
-You can find and pull [the images on docker hub](https://hub.docker.com/r/sidestream/python-poetry).
+You can find and pull [the images on docker hub](https://hub.docker.com/r/sidestream).

--- a/ci-cd/aws-cli-chamber-helm/Dockerfile
+++ b/ci-cd/aws-cli-chamber-helm/Dockerfile
@@ -1,0 +1,5 @@
+FROM segment/chamber:2.10.6 AS chamber
+
+FROM jshimko/kube-tools-aws:3.8.1 AS ci-cd-ready
+
+COPY --from=chamber /chamber /usr/local/bin/chamber

--- a/ci-cd/docker-in-docker-chamber/Dockerfile
+++ b/ci-cd/docker-in-docker-chamber/Dockerfile
@@ -1,0 +1,5 @@
+FROM segment/chamber:2.10.6 AS chamber
+
+FROM docker:20.10.10
+
+COPY --from=chamber /chamber /usr/local/bin/chamber

--- a/python/3.8/poetry/Dockerfile
+++ b/python/3.8/poetry/Dockerfile
@@ -13,6 +13,8 @@ ENV \
     PYTHONDONTWRITEBYTECODE=1
 
 # install poetry
+# before that make sure that we fail on pipe failurese (see https://github.com/hadolint/hadolint/wiki/DL4006)
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 
 # add poetry to path

--- a/python/3.9/poetry/Dockerfile
+++ b/python/3.9/poetry/Dockerfile
@@ -13,6 +13,8 @@ ENV \
     PYTHONDONTWRITEBYTECODE=1
 
 # install poetry
+# before that make sure that we fail on pipe failurese (see https://github.com/hadolint/hadolint/wiki/DL4006)
+# SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 
 # add poetry to path

--- a/python/3.9/poetry/Dockerfile
+++ b/python/3.9/poetry/Dockerfile
@@ -14,7 +14,7 @@ ENV \
 
 # install poetry
 # before that make sure that we fail on pipe failurese (see https://github.com/hadolint/hadolint/wiki/DL4006)
-# SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 
 # add poetry to path


### PR DESCRIPTION
This PR adds: 
- docker-in-docker image with chamber (aka. `secrets`) pre-installed for configurable image building,
- aws-cli + helm + chamber image for configured helm deployments to aws 
- some basic automatic lintring and checking