### PR TITLE
add azure-cli deployment image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,16 @@ data:
       trigger:
         event:
           - pull_request
+    - name: build-ci-cd-aws-az-cli-chamber-helmsman-on-pr
+      repository: ghcr.io/sidestream-tech/dockerfiles/aws-az-cli-chamber-helm
+      path_to_dockerfile: ci-cd/aws-az-cli-chamber-helms/Dockerfile
+      path_to_context: ci-cd/aws-az-cli-chamber-helm/
+      tags_to_cache_from:
+        - "main"
+      trigger:
+        event:
+          - pull_request
+
     # publish images on merge to main
     # publish aws-cli-chamber-helm:main and aws-cli-chamber-helm:$MAIN_COMMIT_SHA
     - name: publish-ci-cd-aws-cli-chamber-helm-merge-main
@@ -80,6 +90,23 @@ data:
           value: https://github.com/sidestream-tech/dockerfiles
       path_to_dockerfile: ci-cd/aws-cli-chamber-helmsman/Dockerfile
       path_to_context: ci-cd/aws-cli-chamber-helmsman/
+      tags_to_cache_from:
+        - "main"
+      trigger:
+        event:
+          - push
+        branch:
+          - main
+    - name: publish-ci-cd-aws-az-cli-chamber-helm-merge-main
+      repository: ghcr.io/sidestream-tech/dockerfiles/aws-az-cli-chamber-helm
+      tags:
+        - "main"
+        - "${DRONE_COMMIT_SHA}"
+      labels:
+        - key: org.opencontainers.image.source
+          value: https://github.com/sidestream-tech/dockerfiles
+      path_to_dockerfile: ci-cd/aws-az-cli-chamber-helm/Dockerfile
+      path_to_context: ci-cd/aws-az-cli-chamber-helm/
       tags_to_cache_from:
         - "main"
       trigger:

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,9 +31,9 @@ data:
       trigger:
         event:
           - pull_request
-    - name: build-ci-cd-aws-az-cli-chamber-helmsman-on-pr
+    - name: build-ci-cd-aws-az-cli-chamber-helm-on-pr
       repository: ghcr.io/sidestream-tech/dockerfiles/aws-az-cli-chamber-helm
-      path_to_dockerfile: ci-cd/aws-az-cli-chamber-helms/Dockerfile
+      path_to_dockerfile: ci-cd/aws-az-cli-chamber-helm/Dockerfile
       path_to_context: ci-cd/aws-az-cli-chamber-helm/
       tags_to_cache_from:
         - "main"
@@ -97,6 +97,7 @@ data:
           - push
         branch:
           - main
+
     - name: publish-ci-cd-aws-az-cli-chamber-helm-merge-main
       repository: ghcr.io/sidestream-tech/dockerfiles/aws-az-cli-chamber-helm
       tags:
@@ -114,6 +115,7 @@ data:
           - push
         branch:
           - main
+
   pipelines:
     - kind: pipeline
       type: kubernetes

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Currently, we offer:
     - `helm` is used to deploy the application
     - `helmsman` is used as a desired state file tooling for helm
     - image name: `sidestream/aws-cli-chamber-helmsman`
+- `ci-cd/aws-az-cli-chamber-helm`: `aws-cli` + `azure-cli` + `chamber`  + `helm` images and files in order to support our continuous delivery, where:
+    - `aws-cli` is used to connect to AWS infrastructure
+    - `azure-cli` is used to connect to Azure infrastructure
+    - `chamber` is used to securely inject secrets into the deployment,
+    - `helm` is used to deploy the application
+    - image name: `sidestream/aws-az-cli-chamber-helm`
 - `ci-cd/docker-in-docker-chamber`: Docker-in-docker (dind) and `chamber` for docker build time configuration injection in CI/CD pipeline
     - image name: `sidestream/docker-in-docker-chamber`
 

--- a/ci-cd/aws-az-cli-chamber-helm/Dockerfile
+++ b/ci-cd/aws-az-cli-chamber-helm/Dockerfile
@@ -4,7 +4,13 @@ FROM jshimko/kube-tools-aws:3.8.1 AS ci-cd-ready
 
 COPY --from=chamber /chamber /usr/local/bin/chamber
 # Install azure cli on alpine
-RUN apk add py3-pip
-RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev cargo make
-RUN pip install --upgrade pip
-RUN pip install azure-cli
+RUN apk add --no-cache -q --virtual=build gcc=10.3.1_git20210424-r2 \ 
+    musl-dev=1.2.2-r3 \
+    python3-dev=3.9.5-r2 \
+    libffi-dev=3.3-r2 \
+    openssl-dev=1.1.1q-r0 \
+    cargo=1.52.1-r1 \
+    make=4.3-r0
+RUN pip install pip==22.2
+RUN pip install --no-cache-dir azure-cli==2.38.0
+RUN apk del --purge build

--- a/ci-cd/aws-az-cli-chamber-helm/Dockerfile
+++ b/ci-cd/aws-az-cli-chamber-helm/Dockerfile
@@ -1,5 +1,4 @@
 FROM segment/chamber:2.10.6 AS chamber
-# FROM mcr.microsoft.com/azure-cli:2.9.1 AS azure-cli
 FROM jshimko/kube-tools-aws:3.8.1 AS ci-cd-ready
 
 COPY --from=chamber /chamber /usr/local/bin/chamber
@@ -14,3 +13,5 @@ RUN apk add --no-cache -q --virtual=build gcc=10.3.1_git20210424-r2 \
 RUN pip install --no-cache-dir pip==22.2
 RUN pip install --no-cache-dir azure-cli==2.38.0
 RUN apk del --purge build
+
+CMD ["/bin/sh"]

--- a/ci-cd/aws-az-cli-chamber-helm/Dockerfile
+++ b/ci-cd/aws-az-cli-chamber-helm/Dockerfile
@@ -11,6 +11,6 @@ RUN apk add --no-cache -q --virtual=build gcc=10.3.1_git20210424-r2 \
     openssl-dev=1.1.1q-r0 \
     cargo=1.52.1-r1 \
     make=4.3-r0
-RUN pip install pip==22.2
+RUN pip install --no-cache-dir pip==22.2
 RUN pip install --no-cache-dir azure-cli==2.38.0
 RUN apk del --purge build

--- a/ci-cd/aws-az-cli-chamber-helm/Dockerfile
+++ b/ci-cd/aws-az-cli-chamber-helm/Dockerfile
@@ -1,0 +1,10 @@
+FROM segment/chamber:2.10.6 AS chamber
+# FROM mcr.microsoft.com/azure-cli:2.9.1 AS azure-cli
+FROM jshimko/kube-tools-aws:3.8.1 AS ci-cd-ready
+
+COPY --from=chamber /chamber /usr/local/bin/chamber
+# Install azure cli on alpine
+RUN apk add py3-pip
+RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev cargo make
+RUN pip install --upgrade pip
+RUN pip install azure-cli


### PR DESCRIPTION
Contributes to #https://github.com/sidestream-tech/textiltiger/pull/174

Dockerfiles which provides the azure-cli needed for the textiltiger production deployment to an azure kubernetes cluster.

Tried to make it as small as possible but for some reason is the `azure-cli` for alpine riughly still 1 GB big, this Issue https://github.com/Azure/azure-cli/issues/19591 is still open so they are working on making it smaller.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable
